### PR TITLE
Add CustomQuery interface and handling (fixes #4).

### DIFF
--- a/code/SwitchFlitController.php
+++ b/code/SwitchFlitController.php
@@ -37,6 +37,11 @@ class SwitchFlitController extends \Controller
 		}
 
 		$records = $dataobject::get();
+
+        if (in_array('SwitchFlit\WithCustomQuery', class_implements($dataobject))) {
+            $records = $dataobject::SwitchFlitQuery($records);
+        }
+
 		$data = [];
 
 		foreach ($records as $record) {

--- a/code/SwitchFlitable.php
+++ b/code/SwitchFlitable.php
@@ -4,7 +4,13 @@ namespace SwitchFlit;
 
 interface SwitchFlitable
 {
+    /**
+     * @return string The title to use in SwitchFlit for this DataObject
+     */
 	public function SwitchFlitTitle();
 
+    /**
+     * @return string The link to use in SwitchFlit for this DataObject
+     */
 	public function SwitchFlitLink();
 }

--- a/code/WithCustomQuery.php
+++ b/code/WithCustomQuery.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SwitchFlit;
+
+interface WithCustomQuery
+{
+    /**
+     * @param \DataList $data The original DataList.
+     * @return \DataList The DataList with custom filters applied.
+     */
+    public static function SwitchFlitQuery(\DataList $data);
+}

--- a/tests/SwitchFlitControllerTest.yml
+++ b/tests/SwitchFlitControllerTest.yml
@@ -1,7 +1,18 @@
-SwitchFlitDemoDataObject:
+SwitchFlitDataObject:
   obj1:
     Name: 'First'
   obj2:
     Name: 'Second'
   obj3:
     Name: 'Third'
+
+SwitchFlitDataObjectWithCustomQuery:
+  obj1:
+    Name: 'First'
+    Type: 'Invalid'
+  obj2:
+    Name: 'Second'
+    Type: 'Valid'
+  obj3:
+    Name: 'Third'
+    Type: 'Invalid'


### PR DESCRIPTION
Easier than originally anticipated!

This PR introduces the `WithCustomQuery` interface, which enforces the `SwitchFlitQuery()` method. This method provides the DataList of records prior to parsing, allowing you to filter and otherwise mess with the list before it is sent to the browser.

Additional test coverage is included.
